### PR TITLE
Add modular training enhancements

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,0 +1,30 @@
+{
+  "training": {
+    "dynamic_loss_adaptation": {
+      "adaptation_rate": 0.05,
+      "smoothing": 0.95,
+      "min_weight": 0.001
+    },
+    "symbolic_feedback_integration": {
+      "feedback_smoothing": 0.8,
+      "scaling": 0.1,
+      "history": 32
+    },
+    "recursive_self_audit_mechanism": {
+      "window": 50,
+      "drift_threshold": 0.1,
+      "overfit_threshold": 0.05
+    },
+    "neural_symbolic_replay_buffer": {
+      "capacity": 128,
+      "min_difficulty": 0.0,
+      "temperature": 1.0
+    },
+    "gradient_resonance_optimization": {
+      "resonance_strength": 0.25,
+      "smoothing": 0.9,
+      "min_scale": 0.5,
+      "max_scale": 1.5
+    }
+  }
+}

--- a/sov_ai/__init__.py
+++ b/sov_ai/__init__.py
@@ -1,5 +1,19 @@
 """Sovereign AI interactive system package."""
 
-from .core import SovAI, run_sov_ai
+from importlib import import_module
+from typing import Any
 
-__all__ = ["SovAI", "run_sov_ai"]
+__all__ = ["SovAI", "run_sov_ai", "training"]
+
+
+def __getattr__(name: str) -> Any:  # pragma: no cover - import side-effect
+    if name in {"SovAI", "run_sov_ai"}:
+        core = import_module("sov_ai.core")
+        globals()["SovAI"] = core.SovAI
+        globals()["run_sov_ai"] = core.run_sov_ai
+        return globals()[name]
+    if name == "training":
+        module = import_module("sov_ai.training")
+        globals()[name] = module
+        return module
+    raise AttributeError(f"module 'sov_ai' has no attribute '{name}'")

--- a/sov_ai/learning.py
+++ b/sov_ai/learning.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import math
 from dataclasses import dataclass
 from typing import Dict, Optional
@@ -33,7 +34,8 @@ class SymbolicLearner:
 
     @staticmethod
     def _hash_token(token: str) -> int:
-        return abs(hash(token))
+        digest = hashlib.blake2b(token.encode("utf-8"), digest_size=16).digest()
+        return int.from_bytes(digest, byteorder="big", signed=False)
 
     def _encode(self, text: str) -> torch.Tensor:
         vector = torch.zeros(self._feature_dim, dtype=torch.float32)

--- a/sov_ai/training/__init__.py
+++ b/sov_ai/training/__init__.py
@@ -1,0 +1,16 @@
+"""Training utilities including adaptive loss, auditing, and replay modules."""
+
+from .dynamic_loss_adaptation import DynamicLossAdaptation
+from .gradient_resonance_optimization import GradientResonanceOptimization
+from .neural_symbolic_replay_buffer import NeuralSymbolicReplayBuffer, ReplayItem
+from .recursive_self_audit_mechanism import RecursiveSelfAuditMechanism
+from .symbolic_feedback_integration import SymbolicFeedbackIntegration
+
+__all__ = [
+    "DynamicLossAdaptation",
+    "GradientResonanceOptimization",
+    "NeuralSymbolicReplayBuffer",
+    "ReplayItem",
+    "RecursiveSelfAuditMechanism",
+    "SymbolicFeedbackIntegration",
+]

--- a/sov_ai/training/_compat.py
+++ b/sov_ai/training/_compat.py
@@ -1,0 +1,140 @@
+"""Backend compatibility helpers for training utilities."""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Literal, Optional, Sequence
+
+BackendLiteral = Literal["torch", "tensorflow", "python"]
+
+try:  # pragma: no cover - optional dependency
+    import torch  # type: ignore
+except Exception:  # pragma: no cover - fallback when torch is unavailable
+    torch = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import tensorflow as tf  # type: ignore
+except Exception:  # pragma: no cover - fallback when tensorflow is unavailable
+    tf = None  # type: ignore
+
+
+def _is_real_torch_tensor(value: Any) -> bool:
+    return (
+        torch is not None
+        and hasattr(value, "detach")
+        and hasattr(value, "shape")
+    )
+
+
+def _is_real_tf_tensor(value: Any) -> bool:
+    return (
+        tf is not None
+        and hasattr(value, "numpy")
+        and hasattr(value, "shape")
+    )
+
+
+def detect_backend(
+    preferred: Optional[BackendLiteral] = None, *candidates: Any
+) -> BackendLiteral:
+    """Return the most appropriate backend for the provided values."""
+
+    if preferred == "torch" and torch is not None:
+        return "torch"
+    if preferred == "tensorflow" and tf is not None:
+        return "tensorflow"
+
+    for value in candidates:
+        if _is_real_torch_tensor(value):
+            return "torch"
+        if _is_real_tf_tensor(value):
+            return "tensorflow"
+
+    if preferred in {"torch", "tensorflow"}:
+        # Preferred backend requested but module unavailable – fall back to python.
+        return "python"
+
+    if torch is not None:
+        return "torch"
+    if tf is not None:
+        return "tensorflow"
+    return "python"
+
+
+def to_scalar(value: Any) -> float:
+    """Convert a tensor-like value to a Python float."""
+
+    if _is_real_torch_tensor(value):
+        return float(value.detach().cpu().item())
+    if _is_real_tf_tensor(value):
+        result = value.numpy()
+        return float(result.item() if hasattr(result, "item") else result)
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        collected = [float(v) for v in value]
+        if not collected:
+            return 0.0
+        return sum(collected) / len(collected)
+    return float(value)
+
+
+def scale_value(value: Any, factor: float, backend: BackendLiteral) -> Any:
+    """Scale a tensor-like value by ``factor`` with graceful fallback."""
+
+    if backend == "torch" and _is_real_torch_tensor(value):  # pragma: no branch - torch path
+        return value * factor
+    if backend == "tensorflow" and _is_real_tf_tensor(value):  # pragma: no branch - tf path
+        return value * factor
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [float(v) * factor for v in value]
+    return to_scalar(value) * factor
+
+
+def add_values(a: Any, b: Any, backend: BackendLiteral) -> Any:
+    """Add tensor-like values, falling back to Python floats."""
+
+    if backend == "torch" and _is_real_torch_tensor(a) and _is_real_torch_tensor(b):
+        return a + b
+    if backend == "tensorflow" and _is_real_tf_tensor(a) and _is_real_tf_tensor(b):
+        return a + b
+    if isinstance(a, Sequence) and isinstance(b, Sequence):
+        length = min(len(a), len(b))
+        return [float(a[i]) + float(b[i]) for i in range(length)]
+    return to_scalar(a) + to_scalar(b)
+
+
+def zeros_like(value: Any, backend: BackendLiteral) -> Any:
+    """Return a zero tensor/list matching the input value."""
+
+    if backend == "torch" and _is_real_torch_tensor(value):
+        return value * 0
+    if backend == "tensorflow" and _is_real_tf_tensor(value):
+        return value * 0
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [0.0 for _ in value]
+    return 0.0
+
+
+def flatten(value: Any, backend: BackendLiteral) -> Iterable[float]:
+    """Yield flattened scalar values for cosine similarity calculations."""
+
+    if backend == "torch" and _is_real_torch_tensor(value):
+        return value.detach().reshape(-1).cpu().tolist()
+    if backend == "tensorflow" and _is_real_tf_tensor(value):
+        return value.numpy().reshape(-1).tolist()
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return [float(v) for v in value]
+    return [to_scalar(value)]
+
+
+def cosine_similarity(a: Any, b: Any, backend: BackendLiteral, eps: float = 1e-8) -> float:
+    """Compute a cosine similarity metric between two tensors/lists."""
+
+    flat_a = list(flatten(a, backend))
+    flat_b = list(flatten(b, backend))
+    if not flat_a or not flat_b:
+        return 0.0
+    dot = sum(x * y for x, y in zip(flat_a, flat_b))
+    norm_a = sum(x * x for x in flat_a) ** 0.5
+    norm_b = sum(y * y for y in flat_b) ** 0.5
+    if norm_a < eps or norm_b < eps:
+        return 0.0
+    return dot / (norm_a * norm_b)

--- a/sov_ai/training/dynamic_loss_adaptation.py
+++ b/sov_ai/training/dynamic_loss_adaptation.py
@@ -1,0 +1,124 @@
+"""Adaptive weighting for multiple loss terms."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, MutableMapping, Optional, Tuple
+
+from ._compat import (
+    BackendLiteral,
+    add_values,
+    detect_backend,
+    scale_value,
+    to_scalar,
+)
+
+
+@dataclass
+class DynamicLossAdaptation:
+    """Maintain adaptive weights for multi-objective training losses."""
+
+    loss_names: Tuple[str, ...]
+    base_weights: Optional[Mapping[str, float]] = None
+    adaptation_rate: float = 0.05
+    smoothing: float = 0.95
+    min_weight: float = 1e-3
+    backend_hint: Optional[BackendLiteral] = None
+
+    _weights: MutableMapping[str, float] = field(init=False, repr=False)
+    _running_loss: MutableMapping[str, float] = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if not self.loss_names:
+            raise ValueError("loss_names must not be empty")
+        if self.base_weights is not None:
+            missing = [name for name in self.loss_names if name not in self.base_weights]
+            if missing:
+                raise ValueError(f"base_weights missing entries for: {missing}")
+            weights = {name: float(self.base_weights[name]) for name in self.loss_names}
+        else:
+            uniform = 1.0 / len(self.loss_names)
+            weights = {name: uniform for name in self.loss_names}
+        total = sum(weights.values())
+        if total <= 0:
+            raise ValueError("base_weights must sum to a positive value")
+        self._weights = {name: max(self.min_weight, weight / total) for name, weight in weights.items()}
+        self._normalise_weights()
+        self._running_loss = {name: 0.0 for name in self.loss_names}
+
+    def _normalise_weights(self) -> None:
+        total = sum(self._weights.values())
+        if total <= 0:
+            uniform = 1.0 / len(self._weights)
+            for name in self._weights:
+                self._weights[name] = uniform
+            return
+        for name in self._weights:
+            self._weights[name] = max(self.min_weight, self._weights[name] / total)
+        total = sum(self._weights.values())
+        if total == 0:
+            uniform = 1.0 / len(self._weights)
+            for name in self._weights:
+                self._weights[name] = uniform
+        else:
+            for name in self._weights:
+                self._weights[name] /= total
+
+    def update(self, losses: Mapping[str, Any]) -> Tuple[Any, Dict[str, float]]:
+        """Update the adaptive weights and return the combined loss."""
+
+        missing = [name for name in self.loss_names if name not in losses]
+        if missing:
+            raise KeyError(f"Missing loss values for: {missing}")
+
+        backend = detect_backend(self.backend_hint, *losses.values())
+        updated: Dict[str, float] = {}
+        for name, value in losses.items():
+            numeric = to_scalar(value)
+            prev = self._running_loss[name]
+            self._running_loss[name] = (
+                self.smoothing * prev + (1.0 - self.smoothing) * numeric
+            )
+            baseline = max(self._running_loss[name], 1e-6)
+            ratio = numeric / baseline
+            inverse = 1.0 / max(ratio, 1e-6)
+            current_weight = self._weights[name]
+            new_weight = (1.0 - self.adaptation_rate) * current_weight + self.adaptation_rate * inverse
+            updated[name] = max(self.min_weight, new_weight)
+
+        self._weights.update(updated)
+        self._normalise_weights()
+
+        combined: Optional[Any] = None
+        for name, value in losses.items():
+            weighted_value = scale_value(value, self._weights[name], backend)
+            if combined is None:
+                combined = weighted_value
+            else:
+                combined = add_values(combined, weighted_value, backend)
+
+        if combined is None:
+            combined = 0.0
+        return combined, dict(self._weights)
+
+    def state_dict(self) -> Dict[str, Any]:
+        """Return a JSON-serialisable snapshot of the adaptor state."""
+
+        return {
+            "weights": dict(self._weights),
+            "running_loss": dict(self._running_loss),
+        }
+
+    def load_state_dict(self, state: Mapping[str, Any]) -> None:
+        """Restore the adaptor state from :func:`state_dict`."""
+
+        weights = state.get("weights")
+        running = state.get("running_loss")
+        if not isinstance(weights, Mapping) or not isinstance(running, Mapping):
+            raise ValueError("Invalid state dictionary")
+        for name in self.loss_names:
+            if name not in weights or name not in running:
+                raise KeyError(f"State missing values for '{name}'")
+        self._weights = {name: float(weights[name]) for name in self.loss_names}
+        self._running_loss = {name: float(running[name]) for name in self.loss_names}
+        self._normalise_weights()

--- a/sov_ai/training/gradient_resonance_optimization.py
+++ b/sov_ai/training/gradient_resonance_optimization.py
@@ -1,0 +1,78 @@
+"""Gradient modulation utilities based on inter-layer coherence."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, MutableMapping, Optional
+
+from ._compat import (
+    BackendLiteral,
+    add_values,
+    cosine_similarity,
+    detect_backend,
+    scale_value,
+)
+
+
+class GradientResonanceOptimization:
+    """Modulate gradients according to inter-layer resonance signals."""
+
+    def __init__(
+        self,
+        resonance_strength: float = 0.25,
+        smoothing: float = 0.9,
+        min_scale: float = 0.5,
+        max_scale: float = 1.5,
+        backend_hint: Optional[BackendLiteral] = None,
+    ) -> None:
+        self._resonance_strength = resonance_strength
+        self._smoothing = smoothing
+        self._min_scale = min_scale
+        self._max_scale = max_scale
+        self._backend_hint = backend_hint
+        self._running_signature: MutableMapping[str, Any] = {}
+
+    def _update_signature(self, name: str, gradient: Any, backend: BackendLiteral) -> float:
+        previous = self._running_signature.get(name)
+        if previous is None:
+            self._running_signature[name] = gradient
+            return 0.0
+        coherence = cosine_similarity(previous, gradient, backend)
+        blended = scale_value(previous, self._smoothing, backend)
+        residual = scale_value(gradient, 1.0 - self._smoothing, backend)
+        try:
+            updated = add_values(blended, residual, backend)
+        except Exception:
+            updated = residual
+        self._running_signature[name] = updated
+        return float(max(-1.0, min(1.0, coherence)))
+
+    def modulate(self, gradients: Mapping[str, Any]) -> Dict[str, Any]:
+        if not gradients:
+            return {}
+        backend = detect_backend(self._backend_hint, *gradients.values())
+        scaled: Dict[str, Any] = {}
+        for name, grad in gradients.items():
+            coherence = self._update_signature(name, grad, backend)
+            scale = 1.0 + self._resonance_strength * coherence
+            scale = max(self._min_scale, min(self._max_scale, scale))
+            scaled[name] = scale_value(grad, scale, backend)
+        return scaled
+
+    def apply(self, gradients: Mapping[str, Any], optimizer: Any) -> Dict[str, Any]:
+        """Apply modulated gradients and step a PyTorch-style optimizer."""
+
+        scaled = self.modulate(gradients)
+        param_groups = getattr(optimizer, "param_groups", None)
+        if param_groups is None:
+            raise TypeError("Optimizer does not expose param_groups for modulation")
+        for group in param_groups:
+            for param in group.get("params", []):
+                name = getattr(param, "name", None)
+                if name and name in scaled:
+                    if getattr(param, "grad", None) is not None:
+                        param.grad = scaled[name]
+        optimizer.step()
+        return scaled
+
+    def reset(self) -> None:
+        self._running_signature.clear()

--- a/sov_ai/training/neural_symbolic_replay_buffer.py
+++ b/sov_ai/training/neural_symbolic_replay_buffer.py
@@ -1,0 +1,107 @@
+"""Replay buffer for challenging training samples."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Deque, Dict, List, Optional
+
+from collections import deque
+
+
+@dataclass
+class ReplayItem:
+    sample: Dict[str, object]
+    difficulty: float
+    metadata: Optional[Dict[str, object]] = None
+
+
+class NeuralSymbolicReplayBuffer:
+    """Prioritise difficult samples for neural-symbolic rehearsal."""
+
+    def __init__(
+        self,
+        capacity: int = 128,
+        min_difficulty: float = 0.0,
+        temperature: float = 1.0,
+    ) -> None:
+        if capacity <= 0:
+            raise ValueError("capacity must be positive")
+        self._capacity = capacity
+        self._min_difficulty = min_difficulty
+        self._temperature = temperature
+        self._items: Deque[ReplayItem] = deque(maxlen=capacity)
+
+    def add(self, sample: Dict[str, object], difficulty: float, metadata: Optional[Dict[str, object]] = None) -> None:
+        if difficulty < self._min_difficulty:
+            return
+        item = ReplayItem(sample=sample, difficulty=float(difficulty), metadata=metadata)
+        self._items.append(item)
+
+    def _sorted_items(self) -> List[ReplayItem]:
+        return sorted(self._items, key=lambda item: item.difficulty, reverse=True)
+
+    def sample(self, batch_size: int, strategy: str = "hybrid") -> List[ReplayItem]:
+        if batch_size <= 0:
+            raise ValueError("batch_size must be positive")
+        items = self._sorted_items()
+        if not items:
+            return []
+        if strategy == "topk":
+            return items[:batch_size]
+        if strategy == "stochastic":
+            weights = [item.difficulty ** self._temperature for item in items]
+            total = sum(weights)
+            if total <= 0:
+                return items[:batch_size]
+            probabilities = [w / total for w in weights]
+            selected: List[ReplayItem] = []
+            for _ in range(min(batch_size, len(items))):
+                cumulative = 0.0
+                from random import random
+
+                r = random()
+                for idx, prob in enumerate(probabilities):
+                    cumulative += prob
+                    if r <= cumulative:
+                        selected.append(items[idx])
+                        break
+            return selected
+        # Hybrid: mix top-k and stochastic sampling.
+        half = max(1, batch_size // 2)
+        top = items[:half]
+        remainder = batch_size - len(top)
+        if remainder <= 0:
+            return top
+        stochastic = self.sample(remainder, strategy="stochastic")
+        combined = top + [item for item in stochastic if item not in top]
+        return combined[:batch_size]
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def state_dict(self) -> Dict[str, object]:
+        return {
+            "capacity": self._capacity,
+            "min_difficulty": self._min_difficulty,
+            "temperature": self._temperature,
+            "items": [
+                {
+                    "sample": item.sample,
+                    "difficulty": item.difficulty,
+                    "metadata": item.metadata,
+                }
+                for item in self._items
+            ],
+        }
+
+    def load_state_dict(self, state: Dict[str, object]) -> None:
+        self._items.clear()
+        self._capacity = int(state.get("capacity", self._capacity))
+        self._min_difficulty = float(state.get("min_difficulty", self._min_difficulty))
+        self._temperature = float(state.get("temperature", self._temperature))
+        for raw in state.get("items", []):
+            self.add(
+                sample=dict(raw.get("sample", {})),
+                difficulty=float(raw.get("difficulty", 0.0)),
+                metadata=raw.get("metadata"),
+            )

--- a/sov_ai/training/recursive_self_audit_mechanism.py
+++ b/sov_ai/training/recursive_self_audit_mechanism.py
@@ -1,0 +1,76 @@
+"""Automated drift and overfitting auditing for training loops."""
+
+from __future__ import annotations
+
+from collections import deque
+from statistics import mean
+from typing import Deque, Dict, Iterable, Mapping, MutableMapping
+
+
+class RecursiveSelfAuditMechanism:
+    """Monitor metric histories and flag drift/overfitting conditions."""
+
+    def __init__(
+        self,
+        window: int = 50,
+        drift_threshold: float = 0.1,
+        overfit_threshold: float = 0.05,
+    ) -> None:
+        if window <= 1:
+            raise ValueError("window must be greater than 1")
+        self._window = window
+        self._drift_threshold = drift_threshold
+        self._overfit_threshold = overfit_threshold
+        self._metrics: MutableMapping[str, Deque[float]] = {}
+
+    def record(self, metrics: Mapping[str, float]) -> None:
+        """Record a new set of metrics into the auditing buffers."""
+
+        for name, value in metrics.items():
+            history = self._metrics.setdefault(name, deque(maxlen=self._window))
+            history.append(float(value))
+
+    def _rolling_mean(self, values: Iterable[float]) -> float:
+        collected = list(values)
+        return mean(collected) if collected else 0.0
+
+    def audit(self) -> Dict[str, bool]:
+        """Return drift and overfitting alerts based on recorded metrics."""
+
+        if not self._metrics:
+            return {"drift_alert": False, "overfit_alert": False}
+
+        drift_alert = False
+        overfit_alert = False
+
+        for name, values in self._metrics.items():
+            if len(values) < 2:
+                continue
+            midpoint = max(1, len(values) // 2)
+            early = self._rolling_mean(list(values)[:midpoint])
+            recent = self._rolling_mean(list(values)[midpoint:])
+            if early == 0:
+                continue
+            change = abs(recent - early) / max(abs(early), 1e-6)
+            if change >= self._drift_threshold:
+                drift_alert = True
+            if name.startswith("train_"):
+                companion = name.replace("train_", "val_", 1)
+                if companion in self._metrics:
+                    val_recent = self._rolling_mean(list(self._metrics[companion])[midpoint:])
+                    gap = val_recent - recent
+                    if gap >= self._overfit_threshold:
+                        overfit_alert = True
+
+        return {"drift_alert": drift_alert, "overfit_alert": overfit_alert}
+
+    def state_dict(self) -> Dict[str, Iterable[float]]:
+        return {name: tuple(history) for name, history in self._metrics.items()}
+
+    def load_state_dict(self, state: Mapping[str, Iterable[float]]) -> None:
+        self._metrics.clear()
+        for name, values in state.items():
+            history = deque(maxlen=self._window)
+            for value in values:
+                history.append(float(value))
+            self._metrics[name] = history

--- a/sov_ai/training/symbolic_feedback_integration.py
+++ b/sov_ai/training/symbolic_feedback_integration.py
@@ -1,0 +1,89 @@
+"""Symbolic reasoning correction layer for model outputs."""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, Deque, Dict, Iterable, Mapping, MutableMapping, Optional
+
+from ._compat import BackendLiteral, detect_backend, zeros_like
+
+
+class SymbolicFeedbackIntegration:
+    """Integrate symbolic feedback signals into numeric model outputs."""
+
+    def __init__(
+        self,
+        symbol_bias: Optional[Mapping[int, float]] = None,
+        feedback_smoothing: float = 0.8,
+        scaling: float = 0.1,
+        history: int = 32,
+        backend_hint: Optional[BackendLiteral] = None,
+    ) -> None:
+        self._bias: MutableMapping[int, float] = (
+            {int(idx): float(bias) for idx, bias in symbol_bias.items()}
+            if symbol_bias
+            else {}
+        )
+        self._feedback_smoothing = feedback_smoothing
+        self._scaling = scaling
+        self._history: Deque[Dict[int, float]] = deque(maxlen=history)
+        self._running_feedback: MutableMapping[int, float] = {}
+        self._backend_hint = backend_hint
+
+    def update_bias(self, updates: Mapping[int, float]) -> None:
+        for idx, value in updates.items():
+            self._bias[int(idx)] = float(value)
+
+    def _prepare_feedback(self, feedback: Optional[Mapping[int, float]]) -> Dict[int, float]:
+        if feedback is None:
+            return {}
+        prepared: Dict[int, float] = {}
+        for key, value in feedback.items():
+            idx = int(key)
+            prepared[idx] = float(value)
+        return prepared
+
+    def apply(self, outputs: Any, feedback: Optional[Mapping[int, float]]) -> Any:
+        """Return outputs adjusted by symbolic feedback signals."""
+
+        prepared = self._prepare_feedback(feedback)
+        if not prepared:
+            return outputs
+
+        backend = detect_backend(self._backend_hint, outputs)
+        adjustments = zeros_like(outputs, backend)
+
+        for idx, value in prepared.items():
+            bias = self._bias.get(idx, 1.0)
+            previous = self._running_feedback.get(idx, 0.0)
+            smoothed = (
+                self._feedback_smoothing * previous
+                + (1.0 - self._feedback_smoothing) * value
+            )
+            self._running_feedback[idx] = smoothed
+            delta = self._scaling * bias * smoothed
+            if isinstance(adjustments, list):
+                if 0 <= idx < len(adjustments):
+                    adjustments[idx] += delta
+            else:
+                try:
+                    adjustments[idx] += delta
+                except Exception:
+                    pass
+        self._history.append(dict(prepared))
+
+        if isinstance(adjustments, list) and isinstance(outputs, Iterable):
+            result = list(outputs)
+            for idx, value in enumerate(adjustments):
+                if 0 <= idx < len(result):
+                    result[idx] += value
+            return result
+
+        try:
+            return outputs + adjustments  # type: ignore[return-value]
+        except Exception:
+            return outputs
+
+    @property
+    def history(self) -> Iterable[Mapping[int, float]]:
+        return tuple(self._history)

--- a/tests/test_learning.py
+++ b/tests/test_learning.py
@@ -1,0 +1,52 @@
+import hashlib
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _not_available(*_args, **_kwargs):  # pragma: no cover - helper for stubbed torch
+    raise RuntimeError("torch functionality is not available in tests")
+
+
+torch_stub = types.ModuleType("torch")
+
+
+class _TensorStub:  # pragma: no cover - placeholder for torch.Tensor type
+    __module__ = "torch"
+
+
+torch_stub.Tensor = _TensorStub
+torch_stub.float32 = "float32"
+torch_stub.zeros = _not_available
+torch_stub.dot = _not_available
+torch_stub.tanh = _not_available
+torch_stub.tensor = _not_available
+torch_stub.linalg = types.SimpleNamespace(norm=_not_available)
+sys.modules["torch"] = torch_stub
+
+learning_path = Path(__file__).resolve().parents[1] / "sov_ai" / "learning.py"
+spec = importlib.util.spec_from_file_location("sov_ai.learning", learning_path)
+learning = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = learning
+spec.loader.exec_module(learning)
+SymbolicLearner = learning.SymbolicLearner
+
+
+def test_hash_token_is_deterministic():
+    feature_dim = 1024
+    token = "example-token"
+
+    idx1 = SymbolicLearner._hash_token(token) % feature_dim
+    idx2 = SymbolicLearner._hash_token(token) % feature_dim
+    assert idx1 == idx2
+
+    expected_digest = hashlib.blake2b(token.encode("utf-8"), digest_size=16).digest()
+    expected_index = int.from_bytes(expected_digest, byteorder="big", signed=False) % feature_dim
+    assert idx1 == expected_index
+
+    other_token = "Example-Token"  # different case to ensure normalization happens only elsewhere
+    idx_other_first = SymbolicLearner._hash_token(other_token) % feature_dim
+    idx_other_second = SymbolicLearner._hash_token(other_token) % feature_dim
+    assert idx_other_first == idx_other_second

--- a/tests/test_training_modules.py
+++ b/tests/test_training_modules.py
@@ -1,0 +1,61 @@
+import random
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from sov_ai.training import (
+    DynamicLossAdaptation,
+    GradientResonanceOptimization,
+    NeuralSymbolicReplayBuffer,
+    RecursiveSelfAuditMechanism,
+    SymbolicFeedbackIntegration,
+)
+
+
+def test_dynamic_loss_adaptation_balances_losses():
+    adaptor = DynamicLossAdaptation(("loss_a", "loss_b"))
+    combined, weights = adaptor.update({"loss_a": 2.0, "loss_b": 1.0})
+    assert isinstance(combined, float)
+    assert abs(sum(weights.values()) - 1.0) < 1e-6
+    second_combined, second_weights = adaptor.update({"loss_a": 0.5, "loss_b": 1.5})
+    assert abs(sum(second_weights.values()) - 1.0) < 1e-6
+    assert second_combined != combined
+
+
+def test_symbolic_feedback_integration_adjusts_outputs():
+    integration = SymbolicFeedbackIntegration(symbol_bias={1: 2.0}, scaling=0.5)
+    outputs = [0.1, 0.2, 0.3]
+    adjusted = integration.apply(outputs, {1: 1.0})
+    assert adjusted[1] > outputs[1]
+
+
+def test_recursive_self_audit_detects_drift_and_overfit():
+    audit = RecursiveSelfAuditMechanism(window=10, drift_threshold=0.2, overfit_threshold=0.1)
+    for _ in range(5):
+        audit.record({"train_loss": 1.0, "val_loss": 1.05})
+    for _ in range(5):
+        audit.record({"train_loss": 0.5, "val_loss": 0.8})
+    result = audit.audit()
+    assert result["drift_alert"] is True
+    assert result["overfit_alert"] is True
+
+
+def test_neural_symbolic_replay_buffer_prioritises_difficult_samples():
+    buffer = NeuralSymbolicReplayBuffer(capacity=5)
+    buffer.add({"text": "easy"}, difficulty=0.1)
+    buffer.add({"text": "medium"}, difficulty=0.5)
+    buffer.add({"text": "hard"}, difficulty=0.9)
+    samples = buffer.sample(2, strategy="topk")
+    assert samples[0].sample["text"] == "hard"
+    assert samples[1].sample["text"] == "medium"
+
+
+def test_gradient_resonance_optimization_scales_gradients():
+    random.seed(42)
+    optimizer = GradientResonanceOptimization(resonance_strength=0.5, min_scale=0.5, max_scale=1.5, backend_hint="python")
+    gradients = {"layer1": [1.0, 1.0], "layer2": [-1.0, -1.0]}
+    first = optimizer.modulate(gradients)
+    second = optimizer.modulate(gradients)
+    assert first["layer1"] != second["layer1"]
+    assert all(abs(v) <= 1.5 for v in second["layer1"])


### PR DESCRIPTION
## Summary
- add a lazily imported training package with adaptive loss balancing, symbolic feedback, self-audit, replay, and gradient resonance utilities for flexible backends
- provide backend compatibility helpers and lazy sov_ai attribute loading to avoid unnecessary heavy imports until needed
- capture default knobs for the new training modules in config.json and back them with focused regression tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e573f7afe083299fd5326fa872f817